### PR TITLE
Update snip 721

### DIFF
--- a/SNIP-721.md
+++ b/SNIP-721.md
@@ -276,8 +276,8 @@ Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimizati
 |token_id  | string (Uint128)|  The ID of the token whose owner and metadata should be displayed                                              |          |
 
 ### PrivateNftInfo
-Returns the public and private metadata about one particular token.  The return value is based on *ERC-721 Metadata JSON Schema*, but directly from the contract, not as a Uri. Only the image link is a Uri.
-If the supplied viewing key is not correct, or if the NFT owner has not set a viewing key, the response should be identical to the response of `NftInfo`.
+Returns the public and private metadata about one particular token.  The return value is based on *ERC-721 Metadata JSON Schema*, but directly from the contract, not as a Uri. Only the image link is a Uri.<br/>
+If the supplied viewing key is not correct, or if the NFT owner has not set a viewing key, the response should be identical to the response of `NftInfo`.<br/>
 Authentication MUST be a resource intensive operation, that takes a significant amount of time to compute. This is because such queries are open to offline brute-force attacks, which can be parallelized to scale linearly with the resources of a motivated attacker.  In addition, authentication MUST perform the same computation even if the user does not have a viewing key set. 
 
 TBD - Will use cases only require a single key-value pair of "string" type added to the *ERC-721 Metadata JSON Schema* base for the private metadata, or will it need to be an "object" type with multiple key-value pairs?

--- a/SNIP-721.md
+++ b/SNIP-721.md
@@ -251,13 +251,13 @@ Authentication response MUST be indistinguishable for both the case of a wrong v
 ### Queries
 All queries below that return only public metadata use the same names as their CW721 counterparts in order to maintain universal compatibility.
 
-#### ContractInfo
+### ContractInfo
 Returns top-level metadata about the contract.  Namely, `name` and `symbol`.
 
 ##### Request parameters
 None
 
-#### NftInfo
+### NftInfo
 Returns the public metadata about one particular token.  The return value is based on *ERC-721 Metadata JSON Schema*, but directly from the contract, not as a Uri. Only the image link is a Uri.
 
 ##### Request Parameters
@@ -266,7 +266,7 @@ Returns the public metadata about one particular token.  The return value is bas
 |-------------|-----------------|------------------------------------------------------------------------------------------------------------|----------|
 |token_id  | string (Uint128)|  The ID of the token whose metadata should be displayed                                                         |          |
 
-#### AllNftInfo
+### AllNftInfo
 Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization for clients needing both.
 
 ##### Request Parameters
@@ -275,7 +275,7 @@ Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimizati
 |-------------|-----------------|------------------------------------------------------------------------------------------------------------|----------|
 |token_id  | string (Uint128)|  The ID of the token whose owner and metadata should be displayed                                              |          |
 
-#### PrivateNftInfo
+### PrivateNftInfo
 Returns the public and private metadata about one particular token.  The return value is based on *ERC-721 Metadata JSON Schema*, but directly from the contract, not as a Uri. Only the image link is a Uri.
 If the supplied viewing key is not correct, or if the NFT owner has not set a viewing key, the response should be identical to the response of `NftInfo`.
 Authentication MUST be a resource intensive operation, that takes a significant amount of time to compute. This is because such queries are open to offline brute-force attacks, which can be parallelized to scale linearly with the resources of a motivated attacker.  In addition, authentication MUST perform the same computation even if the user does not have a viewing key set. 


### PR DESCRIPTION
I noticed that the document was using two different conventions in specifying the name and request parameters, depending on whether it was copied from the CW721 spec or from the SNIP-20 spec.  I went with the tabular format used in the SNIP-20 spec, but didn't change any sections other than Metadata in case the CW721 style was preferred.
Also, I didn't change the name of NftInfo/AllNftInfo to PublicNftInfo/AllPublicNftInfo because I thought it would be best to maintain the naming convention set by CW721 as that is likely what interNFT is planning on using.