### PR TITLE
Fix parameter name

### DIFF
--- a/SNIP-24.md
+++ b/SNIP-24.md
@@ -173,15 +173,15 @@ A way for users to revoke permits that they signed in the past.
 
 #### Request
 
-| Name    | Type   | Description                                              | optional |
-| ------- | ------ | -------------------------------------------------------- | -------- |
-| name    | string | The name of the permit                                   | no       |
-| padding | string | Ignored string used to maintain constant-length messages | yes      |
+| Name        | Type   | Description                                              | optional |
+| ----------- | ------ | -------------------------------------------------------- | -------- |
+| permit_name | string | The name of the permit                                   | no       |
+| padding     | string | Ignored string used to maintain constant-length messages | yes      |
 
 ```json
 {
   "revoke_permit": {
-    "name": "some name"
+    "permit_name": "some name"
   }
 }
 ```


### PR DESCRIPTION
The RevokePermit message expects `permit_name`, however the documentation incorrectly listed this parameter as `name`.